### PR TITLE
Bump version to 1.0.22 and update metadata

### DIFF
--- a/Simple.Service.Monitoring.Extensions/Simple.Service.Monitoring.Extensions.csproj
+++ b/Simple.Service.Monitoring.Extensions/Simple.Service.Monitoring.Extensions.csproj
@@ -9,16 +9,16 @@
 		<Copyright>Turrican Software</Copyright>
 		<PackageProjectUrl>https://github.com/turric4n/Dotnet.Simple.Service.Monitoring</PackageProjectUrl>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.0.21</Version>
-    <AssemblyVersion>1.0.21</AssemblyVersion>
-    <FileVersion>1.0.21</FileVersion>
+    <Version>1.0.22</Version>
+    <AssemblyVersion>1.0.22</AssemblyVersion>
+    <FileVersion>1.0.22</FileVersion>
     <Authors>Turrican aka Enrique Fuentes</Authors>
     <Company>Turrican Software</Company>
 		<PackageTags>HealthChecks, Monitoring, .NET, C#</PackageTags>
 		<RepositoryType>GIT</RepositoryType>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Title>Simple Service Monitoring Extensions</Title>
-    <Copyright>Turrican 2025</Copyright>
+    <Copyright>Turrican 2026</Copyright>
     <PackageIcon>icon.png</PackageIcon>
 	</PropertyGroup>
 

--- a/Simple.Service.Monitoring.Library/Simple.Service.Monitoring.Library.csproj
+++ b/Simple.Service.Monitoring.Library/Simple.Service.Monitoring.Library.csproj
@@ -9,9 +9,9 @@
 		<PackageProjectUrl>https://github.com/turric4n/Dotnet.Simple.Service.Monitoring</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/turric4n/Dotnet.Simple.Service.Monitoring</RepositoryUrl>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.0.21</Version>
-    <AssemblyVersion>1.0.21</AssemblyVersion>
-    <FileVersion>1.0.21</FileVersion>
+    <Version>1.0.22</Version>
+    <AssemblyVersion>1.0.22</AssemblyVersion>
+    <FileVersion>1.0.22</FileVersion>
     <Authors>Turrican aka Enrique Fuentes</Authors>
 		<Company>Turrican Software</Company>
 		<PackageTags>HealthChecks, Monitoring, .NET, C#</PackageTags>
@@ -19,7 +19,7 @@
 		<UserSecretsId>4f22cd28-9aa4-44c0-82d2-ce640fa480c4</UserSecretsId>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Title>Simple Service Monitoring Library</Title>
-    <Copyright>Turrican 2025</Copyright>
+    <Copyright>Turrican 2026</Copyright>
     <PackageIcon>icon.png</PackageIcon>
 	</PropertyGroup>
 

--- a/Simple.Service.Monitoring.UI.Extensions/Simple.Service.Monitoring.UI.Extensions.csproj
+++ b/Simple.Service.Monitoring.UI.Extensions/Simple.Service.Monitoring.UI.Extensions.csproj
@@ -9,15 +9,15 @@
 		<PackageProjectUrl>https://github.com/turric4n/Dotnet.Simple.Service.Monitoring</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/turric4n/Dotnet.Simple.Service.Monitoring</RepositoryUrl>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.0.21</Version>
-    <AssemblyVersion>1.0.21</AssemblyVersion>
-    <FileVersion>1.0.21</FileVersion>
+    <Version>1.0.22</Version>
+    <AssemblyVersion>1.0.22</AssemblyVersion>
+    <FileVersion>1.0.22</FileVersion>
     <Authors>Turrican aka Enrique Fuentes</Authors>
 		<Company>Turrican Software</Company>
 		<PackageTags>HealthChecks, Monitoring, .NET, C#</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Title>Simple Service Monitoring UI Extensions</Title>
-    <Copyright>Turrican 2025</Copyright>
+    <Copyright>Turrican 2026</Copyright>
     <PackageIcon>icon.png</PackageIcon>
 	</PropertyGroup>
 

--- a/Simple.Service.Monitoring.UI/Simple.Service.Monitoring.UI.csproj
+++ b/Simple.Service.Monitoring.UI/Simple.Service.Monitoring.UI.csproj
@@ -9,15 +9,15 @@
 		<PackageProjectUrl>https://github.com/turric4n/Dotnet.Simple.Service.Monitoring</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/turric4n/Dotnet.Simple.Service.Monitoring</RepositoryUrl>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-		<Version>1.0.21</Version>
-		<AssemblyVersion>1.0.21</AssemblyVersion>
-		<FileVersion>1.0.21</FileVersion>
+		<Version>1.0.22</Version>
+		<AssemblyVersion>1.0.22</AssemblyVersion>
+		<FileVersion>1.0.22</FileVersion>
 		<Authors>Turrican aka Enrique Fuentes</Authors>
 		<Company>Turrican Software</Company>
 		<PackageTags>HealthChecks, Monitoring, .NET, C#</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Title>Simple Service Monitoring UI</Title>
-    <Copyright>Turrican 2025</Copyright>
+    <Copyright>Turrican 2026</Copyright>
     <PackageIcon>icon.png</PackageIcon>
 	</PropertyGroup>
 

--- a/Simple.Service.Monitoring/Simple.Service.Monitoring.sln
+++ b/Simple.Service.Monitoring/Simple.Service.Monitoring.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.4.33403.182
+# Visual Studio Version 18
+VisualStudioVersion = 18.2.11415.280 d18.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Simple.Service.Monitoring", "Simple.Service.Monitoring.csproj", "{62BF283C-3E63-4E82-84BD-8775D59F1E25}"
 EndProject


### PR DESCRIPTION
Incremented all project versions to 1.0.22 and updated copyright year to 2026. Upgraded solution file to Visual Studio 18.2. No code or logic changes included.