### PR TITLE
Refactor Elasticsearch health check to use HttpClient

### DIFF
--- a/Simple.Service.Monitoring.Extensions/Simple.Service.Monitoring.Extensions.csproj
+++ b/Simple.Service.Monitoring.Extensions/Simple.Service.Monitoring.Extensions.csproj
@@ -9,9 +9,9 @@
 		<Copyright>Turrican Software</Copyright>
 		<PackageProjectUrl>https://github.com/turric4n/Dotnet.Simple.Service.Monitoring</PackageProjectUrl>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.0.22</Version>
-    <AssemblyVersion>1.0.22</AssemblyVersion>
-    <FileVersion>1.0.22</FileVersion>
+    <Version>1.0.23</Version>
+    <AssemblyVersion>1.0.23</AssemblyVersion>
+    <FileVersion>1.0.23</FileVersion>
     <Authors>Turrican aka Enrique Fuentes</Authors>
     <Company>Turrican Software</Company>
 		<PackageTags>HealthChecks, Monitoring, .NET, C#</PackageTags>

--- a/Simple.Service.Monitoring.Library/Monitoring/Implementations/HttpServiceMonitoring.cs
+++ b/Simple.Service.Monitoring.Library/Monitoring/Implementations/HttpServiceMonitoring.cs
@@ -41,7 +41,8 @@ namespace Simple.Service.Monitoring.Library.Monitoring.Implementations
         protected internal override void SetMonitoring()
         {
             var endpoints = HealthCheck.EndpointOrHost.Split(',').Select(e => new Uri(e.Trim())).ToList();
-            var timeout = TimeSpan.FromMilliseconds(HealthCheck.HealthCheckConditions.HttpBehaviour.HttpTimeoutMs);
+            var timeoutMs = HealthCheck.HealthCheckConditions.HttpBehaviour.HttpTimeoutMs;
+            var timeout = timeoutMs > 0 ? TimeSpan.FromMilliseconds(timeoutMs) : TimeSpan.FromSeconds(30);
             var expectedCode = HealthCheck.HealthCheckConditions.HttpBehaviour.HttpExpectedCode;
             var httpVerb = HealthCheck.HealthCheckConditions.HttpBehaviour.HttpVerb;
 
@@ -68,7 +69,7 @@ namespace Simple.Service.Monitoring.Library.Monitoring.Implementations
         
         private static readonly HttpClient _httpClient = new HttpClient
         {
-            Timeout = Timeout.InfiniteTimeSpan // Timeout controlled per-request via CancellationToken
+            Timeout = Timeout.InfiniteTimeSpan
         };
 
         public HttpHealthCheck(List<Uri> endpoints, TimeSpan timeout, int expectedStatusCode, HttpVerb httpVerb)

--- a/Simple.Service.Monitoring.Library/Simple.Service.Monitoring.Library.csproj
+++ b/Simple.Service.Monitoring.Library/Simple.Service.Monitoring.Library.csproj
@@ -9,9 +9,9 @@
 		<PackageProjectUrl>https://github.com/turric4n/Dotnet.Simple.Service.Monitoring</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/turric4n/Dotnet.Simple.Service.Monitoring</RepositoryUrl>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.0.22</Version>
-    <AssemblyVersion>1.0.22</AssemblyVersion>
-    <FileVersion>1.0.22</FileVersion>
+    <Version>1.0.23</Version>
+    <AssemblyVersion>1.0.23</AssemblyVersion>
+    <FileVersion>1.0.23</FileVersion>
     <Authors>Turrican aka Enrique Fuentes</Authors>
 		<Company>Turrican Software</Company>
 		<PackageTags>HealthChecks, Monitoring, .NET, C#</PackageTags>
@@ -25,7 +25,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="CuttingEdge.Conditions.NetStandard" Version="1.2.0" />
-		<PackageReference Include="Elastic.Clients.Elasticsearch" Version="9.2.2" />
 		<PackageReference Include="Hangfire.Core" Version="1.8.22" />
 		<PackageReference Include="InfluxDB.Collector" Version="1.1.1" />
 		<PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.2" />

--- a/Simple.Service.Monitoring.Tests/Acceptance/Docker/DockerElasticsearchAcceptanceTests.cs
+++ b/Simple.Service.Monitoring.Tests/Acceptance/Docker/DockerElasticsearchAcceptanceTests.cs
@@ -78,8 +78,11 @@ namespace Simple.Service.Monitoring.Tests.Acceptance.Docker
             // Delete index if it exists
             await client.Indices.DeleteAsync(indexName);
 
-            // Create new index
-            await client.Indices.CreateAsync(indexName);
+            // Create new index with 0 replicas for single-node cluster
+            await client.Indices.CreateAsync(indexName, c => c
+                .Settings(s => s
+                    .NumberOfReplicas(0)
+                    .NumberOfShards(1)));
 
             // Index some test documents
             await client.IndexAsync(new

--- a/Simple.Service.Monitoring.Tests/Simple.Service.Monitoring.Tests.csproj
+++ b/Simple.Service.Monitoring.Tests/Simple.Service.Monitoring.Tests.csproj
@@ -19,6 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="9.2.2" />
     <PackageReference Include="FluentAssertions" Version="8.8.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.2" />


### PR DESCRIPTION
Removed Elastic.Clients.Elasticsearch from main library and replaced with direct HTTP calls for cluster health checks. Improved health status reporting and error messages. Updated HTTP health check timeout logic. Adjusted test index creation for single-node Elasticsearch in acceptance tests. Bumped version to 1.0.23.