### PR TITLE
Add support for custom HTTP headers in health checks

### DIFF
--- a/Simple.Service.Monitoring.Library/Models/HttpBehaviour.cs
+++ b/Simple.Service.Monitoring.Library/Models/HttpBehaviour.cs
@@ -1,4 +1,6 @@
-﻿namespace Simple.Service.Monitoring.Library.Models
+﻿using System.Collections.Generic;
+
+namespace Simple.Service.Monitoring.Library.Models
 {
     public enum HttpVerb
     {
@@ -9,8 +11,14 @@
     }
     public class HttpBehaviour : ConnectionBehaviour
     {
+        public HttpBehaviour()
+        {
+            CustomHttpHeaders = new Dictionary<string, string>();
+        }
+
         public int HttpExpectedCode { get; set; } = 200;
         public int HttpTimeoutMs { get; set; } = 5000;
         public HttpVerb HttpVerb { get; set; }
+        public Dictionary<string, string> CustomHttpHeaders { get; set; }
     }
 }

--- a/Simple.Service.Monitoring.Library/Monitoring/Implementations/HttpServiceMonitoring.cs
+++ b/Simple.Service.Monitoring.Library/Monitoring/Implementations/HttpServiceMonitoring.cs
@@ -98,11 +98,15 @@ namespace Simple.Service.Monitoring.Library.Monitoring.Implementations
                     cts.CancelAfter(_timeout);
 
                     using var request = new HttpRequestMessage(GetHttpMethod(_httpVerb), endpoint);
-                    request.Headers.Add("User-Agent", "HealthChecks");
 
                     foreach (var header in _customHeaders)
                     {
                         request.Headers.Add(header.Key, header.Value);
+                    }
+
+                    if (!_customHeaders.ContainsKey("User-Agent"))
+                    {
+                        request.Headers.Add("User-Agent", "HealthChecks");
                     }
 
                     var response = await _httpClient.SendAsync(request, cts.Token);

--- a/Simple.Service.Monitoring.Tests/Acceptance/Docker/DockerRedisAcceptanceTests.cs
+++ b/Simple.Service.Monitoring.Tests/Acceptance/Docker/DockerRedisAcceptanceTests.cs
@@ -130,7 +130,7 @@ namespace Simple.Service.Monitoring.Tests.Acceptance.Docker
             var value = await db.StringGetAsync("health:check");
             value.ToString().Should().Be("test");
             
-            redis.Dispose();
+            await redis.DisposeAsync();
 
             // Now test the health check
             var healthCheck = new ServiceHealthCheck

--- a/Simple.Service.Monitoring.Tests/Monitors/HttpServiceMonitoringShould.cs
+++ b/Simple.Service.Monitoring.Tests/Monitors/HttpServiceMonitoringShould.cs
@@ -124,5 +124,195 @@ namespace Simple.Service.Monitoring.Tests.Monitors
             Action act = () => httpendpointmonitoring.SetUp();
             act.Should().Throw<MalformedUriException>();
         }
+
+        [Test]
+        public void Should_Support_Custom_Headers_In_Http_Request()
+        {
+            //Arrange
+            var customHeaders = new System.Collections.Generic.Dictionary<string, string>
+            {
+                { "Authorization", "Bearer test-token" },
+                { "X-API-Key", "test-key" }
+            };
+
+            var httpendpointhealthcheck = new ServiceHealthCheck()
+            {
+                Name = "testhealthcheck-with-headers",
+                HealthCheckConditions = new HealthCheckConditions()
+                {
+                    HttpBehaviour = new HttpBehaviour()
+                    {
+                        HttpExpectedCode = 200,
+                        HttpVerb = HttpVerb.Get,
+                        CustomHttpHeaders = customHeaders
+                    },
+                },
+                AlertBehaviour = null,
+                EndpointOrHost = "https://www.google.com",
+                ServiceType = ServiceType.Http
+            };
+            //Act
+            var httpendpointmonitoring = new HttpServiceMonitoring(healthChecksBuilder, httpendpointhealthcheck);
+            //Assert
+            Action act = () => httpendpointmonitoring.SetUp();
+            act.Should().NotThrow();
+        }
+
+        [Test]
+        public void Should_Work_Without_Custom_Headers()
+        {
+            //Arrange
+            var httpendpointhealthcheck = new ServiceHealthCheck()
+            {
+                Name = "testhealthcheck-no-headers",
+                HealthCheckConditions = new HealthCheckConditions()
+                {
+                    HttpBehaviour = new HttpBehaviour()
+                    {
+                        HttpExpectedCode = 200,
+                        HttpVerb = HttpVerb.Get,
+                        CustomHttpHeaders = null // Explicitly null
+                    },
+                },
+                AlertBehaviour = null,
+                EndpointOrHost = "https://www.google.com",
+                ServiceType = ServiceType.Http
+            };
+            //Act
+            var httpendpointmonitoring = new HttpServiceMonitoring(healthChecksBuilder, httpendpointhealthcheck);
+            //Assert
+            Action act = () => httpendpointmonitoring.SetUp();
+            act.Should().NotThrow();
+        }
+
+        [Test]
+        public void Should_Support_Multiple_Custom_Headers()
+        {
+            //Arrange
+            var customHeaders = new System.Collections.Generic.Dictionary<string, string>
+            {
+                { "Authorization", "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..." },
+                { "X-API-Key", "sk_live_abc123" },
+                { "X-Request-ID", "health-check-001" },
+                { "X-Correlation-ID", "monitoring-12345" },
+                { "Accept", "application/json" }
+            };
+
+            var httpendpointhealthcheck = new ServiceHealthCheck()
+            {
+                Name = "testhealthcheck-multiple-headers",
+                HealthCheckConditions = new HealthCheckConditions()
+                {
+                    HttpBehaviour = new HttpBehaviour()
+                    {
+                        HttpExpectedCode = 200,
+                        HttpVerb = HttpVerb.Get,
+                        CustomHttpHeaders = customHeaders
+                    },
+                },
+                AlertBehaviour = null,
+                EndpointOrHost = "https://www.google.com",
+                ServiceType = ServiceType.Http
+            };
+            //Act
+            var httpendpointmonitoring = new HttpServiceMonitoring(healthChecksBuilder, httpendpointhealthcheck);
+            //Assert
+            Action act = () => httpendpointmonitoring.SetUp();
+            act.Should().NotThrow();
+        }
+
+        [Test]
+        public void Should_Support_Custom_Headers_With_Multiple_Endpoints()
+        {
+            //Arrange
+            var customHeaders = new System.Collections.Generic.Dictionary<string, string>
+            {
+                { "Authorization", "Bearer shared-token" },
+                { "X-Environment", "Testing" }
+            };
+
+            var httpendpointhealthcheck = new ServiceHealthCheck()
+            {
+                Name = "testhealthcheck-multi-endpoint-headers",
+                HealthCheckConditions = new HealthCheckConditions()
+                {
+                    HttpBehaviour = new HttpBehaviour()
+                    {
+                        HttpExpectedCode = 200,
+                        HttpVerb = HttpVerb.Get,
+                        CustomHttpHeaders = customHeaders
+                    },
+                },
+                AlertBehaviour = null,
+                EndpointOrHost = "https://www.google.com,https://www.bing.com",
+                ServiceType = ServiceType.Http
+            };
+            //Act
+            var httpendpointmonitoring = new HttpServiceMonitoring(healthChecksBuilder, httpendpointhealthcheck);
+            //Assert
+            Action act = () => httpendpointmonitoring.SetUp();
+            act.Should().NotThrow();
+        }
+
+        [Test]
+        public void Should_Support_Empty_Custom_Headers_Dictionary()
+        {
+            //Arrange
+            var customHeaders = new System.Collections.Generic.Dictionary<string, string>();
+
+            var httpendpointhealthcheck = new ServiceHealthCheck()
+            {
+                Name = "testhealthcheck-empty-headers",
+                HealthCheckConditions = new HealthCheckConditions()
+                {
+                    HttpBehaviour = new HttpBehaviour()
+                    {
+                        HttpExpectedCode = 200,
+                        HttpVerb = HttpVerb.Get,
+                        CustomHttpHeaders = customHeaders // Empty but not null
+                    },
+                },
+                AlertBehaviour = null,
+                EndpointOrHost = "https://www.google.com",
+                ServiceType = ServiceType.Http
+            };
+            //Act
+            var httpendpointmonitoring = new HttpServiceMonitoring(healthChecksBuilder, httpendpointhealthcheck);
+            //Assert
+            Action act = () => httpendpointmonitoring.SetUp();
+            act.Should().NotThrow();
+        }
+
+        [Test]
+        public void Should_Support_Custom_UserAgent_Header()
+        {
+            //Arrange
+            var customHeaders = new System.Collections.Generic.Dictionary<string, string>
+            {
+                { "User-Agent", "MyCompany-HealthMonitor/2.0" }
+            };
+
+            var httpendpointhealthcheck = new ServiceHealthCheck()
+            {
+                Name = "testhealthcheck-custom-useragent",
+                HealthCheckConditions = new HealthCheckConditions()
+                {
+                    HttpBehaviour = new HttpBehaviour()
+                    {
+                        HttpExpectedCode = 200,
+                        HttpVerb = HttpVerb.Get,
+                        CustomHttpHeaders = customHeaders
+                    },
+                },
+                AlertBehaviour = null,
+                EndpointOrHost = "https://www.google.com",
+                ServiceType = ServiceType.Http
+            };
+            //Act
+            var httpendpointmonitoring = new HttpServiceMonitoring(healthChecksBuilder, httpendpointhealthcheck);
+            //Assert
+            Action act = () => httpendpointmonitoring.SetUp();
+            act.Should().NotThrow();
+        }
     }
 }

--- a/Simple.Service.Monitoring.Tests/Publishers/TelegramPublisherIntegrationShould.cs
+++ b/Simple.Service.Monitoring.Tests/Publishers/TelegramPublisherIntegrationShould.cs
@@ -24,15 +24,15 @@ namespace Simple.Service.Monitoring.Tests.Publishers
     [TestFixture(Category = "Integration")]
     [Category("TelegramPublisher")]
     [Category("RealAPI")]
-    //[Explicit("Requires real Telegram bot credentials and sends actual messages")]
+    [Explicit("Requires real Telegram bot credentials and sends actual messages")]
     public class TelegramPublisherIntegrationShould
     {
         private IHealthChecksBuilder _healthChecksBuilder;
         private TelegramTransportSettings _telegramSettings;
 
         // ⚠️ CONFIGURE THESE VALUES BEFORE RUNNING TESTS ⚠️
-        private const string BOT_API_TOKEN = "6030340647:AAGnXhQsziJUsv8eb7ZC2Am_-qpKdDV5rLQ"; // e.g., "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11"
-        private const string CHAT_ID = "-960612732";         // e.g., "-1001234567890" or "123456789"
+        private const string BOT_API_TOKEN = "YOUR_BOT_TOKEN_HERE"; // e.g., "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11"
+        private const string CHAT_ID = "YOUR_CHAT_ID_HERE";         // e.g., "-1001234567890" or "123456789"
 
         [SetUp]
         public void Setup()

--- a/Simple.Service.Monitoring.Tests/Publishers/TelegramPublisherIntegrationShould.cs
+++ b/Simple.Service.Monitoring.Tests/Publishers/TelegramPublisherIntegrationShould.cs
@@ -31,8 +31,8 @@ namespace Simple.Service.Monitoring.Tests.Publishers
         private TelegramTransportSettings _telegramSettings;
 
         // ⚠️ CONFIGURE THESE VALUES BEFORE RUNNING TESTS ⚠️
-        private const string BOT_API_TOKEN = "YOUR_BOT_TOKEN_HERE"; // e.g., "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11"
-        private const string CHAT_ID = "YOUR_CHAT_ID_HERE";         // e.g., "-1001234567890" or "123456789"
+        private const string BOT_API_TOKEN = "6030340647:AAGnXhQsziJUsv8eb7ZC2Am_-qpKdDV5rLQ"; // e.g., "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11"
+        private const string CHAT_ID = "-960612732";         // e.g., "-1001234567890" or "123456789"
 
         [SetUp]
         public void Setup()


### PR DESCRIPTION
- Introduced CustomHttpHeaders property to HttpBehaviour
- HttpServiceMonitoring and HttpHealthCheck now handle custom headers
- Added tests for custom header scenarios (multiple, empty, null, User-Agent, multi-endpoint)
- Improved Redis test with async disposal
- Updated Telegram publisher test credentials for integration